### PR TITLE
Reorganization and cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,8 @@ PhoneGrammar >> defineGrammar
   ntPhoneNumber --> ntStartBlock, ' ', ntBlock, ' ', ntBlock, ' ', ntBlock, ' ', ntBlock.
   ntStartBlock --> '0', ($1-$7).
   ntBlock --> ($0-$9), ($0-$9).
-```
-We should also specify the start symbol
-```smalltalk
-PhoneGrammar >> start
-
+  
+  "Specify the start symbol"
   ^ ntPhoneNumber
 ```
 *et voilà*, the grammar is already ready to generate some phone numbers!

--- a/src/Gnocco-Benchmarks/GncFullBenchmarkResult.class.st
+++ b/src/Gnocco-Benchmarks/GncFullBenchmarkResult.class.st
@@ -9,7 +9,7 @@ Class {
 		'outData',
 		'plot'
 	],
-	#category : #'Gnocco-Fuzzing Artifact'
+	#category : #'Gnocco-Benchmarks'
 }
 
 { #category : #serializing }

--- a/src/Gnocco-Benchmarks/GncObjectGraph.class.st
+++ b/src/Gnocco-Benchmarks/GncObjectGraph.class.st
@@ -27,7 +27,7 @@ Class {
 		'canvas',
 		'nbEdges'
 	],
-	#category : #'Gnocco-Fuzzing Artifact'
+	#category : #'Gnocco-Benchmarks'
 }
 
 { #category : #'instance creation' }

--- a/src/Gnocco-Benchmarks/GncPoorlySerialized.class.st
+++ b/src/Gnocco-Benchmarks/GncPoorlySerialized.class.st
@@ -6,7 +6,7 @@ Class {
 	#instVars : [
 		'data'
 	],
-	#category : #Gnocco
+	#category : #'Gnocco-Benchmarks'
 }
 
 { #category : #benchmarking }

--- a/src/Gnocco-Benchmarks/GncSingleBenchmarkResult.class.st
+++ b/src/Gnocco-Benchmarks/GncSingleBenchmarkResult.class.st
@@ -6,7 +6,7 @@ Class {
 		'gctime',
 		'dataSize'
 	],
-	#category : #'Gnocco-Fuzzing Artifact'
+	#category : #'Gnocco-Benchmarks'
 }
 
 { #category : #accessing }

--- a/src/Gnocco-Benchmarks/GncStonGrammar.class.st
+++ b/src/Gnocco-Benchmarks/GncStonGrammar.class.st
@@ -20,7 +20,7 @@ Class {
 		'ntObjectInstance',
 		'ntClassDigit'
 	],
-	#category : #'Gnocco-Grammar'
+	#category : #'Gnocco-Benchmarks'
 }
 
 { #category : #initialization }

--- a/src/Gnocco-Benchmarks/GncStonGrammarTestCase.class.st
+++ b/src/Gnocco-Benchmarks/GncStonGrammarTestCase.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : #GncStonGrammarTestCase,
+	#superclass : #TestCase,
+	#category : #'Gnocco-Benchmarks'
+}
+
+{ #category : #tests }
+GncStonGrammarTestCase >> setUp [
+
+	super setUp.
+	GncFuzzyClass setupFuzzyClasses: 9
+]
+
+{ #category : #tests }
+GncStonGrammarTestCase >> tearDown [
+
+	GncFuzzyClass removeFuzzyClasses: 9.
+	super tearDown
+]
+
+{ #category : #tests }
+GncStonGrammarTestCase >> testCanGenerateCost [
+
+	| grammar generator minimumTreeHeight ast |
+	generator := GncGrammarGenerator new
+		             maxHeightCost: 0;
+		             seed: 17;
+		             yourself.
+	grammar := GncStonGrammar new.
+	minimumTreeHeight := grammar minHeight.
+	self assert: minimumTreeHeight isFinite. "the grammar can produce a tree"
+	ast := grammar generateAst: generator.
+	self assert: ast minHeight equals: minimumTreeHeight
+]
+
+{ #category : #tests }
+GncStonGrammarTestCase >> testStonSyntax [
+
+	| grammar |
+	grammar := GncStonGrammar new.
+	1 to: 100 do: [ :j |
+		| result |
+		result := STON reader
+			          on: (grammar generate: (GncGrammarGenerator new
+							            maxHeightCost: 20;
+							            yourself)) readStream;
+			          next.
+		self assert: (result class name beginsWith: 'GncFuzzyClass') ]
+]

--- a/src/Gnocco-Benchmarks/GncStupidStream.class.st
+++ b/src/Gnocco-Benchmarks/GncStupidStream.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GncStupidStream,
 	#superclass : #Stream,
-	#category : #'Gnocco-Fuzzing Artifact'
+	#category : #'Gnocco-Benchmarks'
 }
 
 { #category : #'instance creation' }

--- a/src/Gnocco-Benchmarks/TBenchmarkable.trait.st
+++ b/src/Gnocco-Benchmarks/TBenchmarkable.trait.st
@@ -8,7 +8,7 @@ Classes that use me should be data whose serialization is to be benchmarked. To 
 "
 Trait {
 	#name : #TBenchmarkable,
-	#category : #'Gnocco-Fuzzing Artifact'
+	#category : #'Gnocco-Benchmarks'
 }
 
 { #category : #'instance creation' }

--- a/src/Gnocco-Benchmarks/package.st
+++ b/src/Gnocco-Benchmarks/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Gnocco-Benchmarks' }

--- a/src/Gnocco-GeneticMutation/GncBasicGenerator.class.st
+++ b/src/Gnocco-GeneticMutation/GncBasicGenerator.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'randomStream'
 	],
-	#category : #'Gnocco-Genetic Optimization'
+	#category : #'Gnocco-GeneticMutation'
 }
 
 { #category : #initialization }

--- a/src/Gnocco-GeneticMutation/GncCharParameter.class.st
+++ b/src/Gnocco-GeneticMutation/GncCharParameter.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'char'
 	],
-	#category : #'Gnocco-Genetic Optimization'
+	#category : #'Gnocco-GeneticMutation'
 }
 
 { #category : #'instance creation' }

--- a/src/Gnocco-GeneticMutation/GncGrammarIndividual.class.st
+++ b/src/Gnocco-GeneticMutation/GncGrammarIndividual.class.st
@@ -5,7 +5,7 @@ Class {
 		'grammar',
 		'data'
 	],
-	#category : #'Gnocco-Genetic Optimization'
+	#category : #'Gnocco-GeneticMutation'
 }
 
 { #category : #'instance creation' }

--- a/src/Gnocco-GeneticMutation/GncGrammarPopulation.class.st
+++ b/src/Gnocco-GeneticMutation/GncGrammarPopulation.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'grammarClass'
 	],
-	#category : #'Gnocco-Genetic Optimization'
+	#category : #'Gnocco-GeneticMutation'
 }
 
 { #category : #'instance creation' }

--- a/src/Gnocco-GeneticMutation/GncIndividual.class.st
+++ b/src/Gnocco-GeneticMutation/GncIndividual.class.st
@@ -5,7 +5,7 @@ Class {
 		'score',
 		'generator'
 	],
-	#category : #'Gnocco-Genetic Optimization'
+	#category : #'Gnocco-GeneticMutation'
 }
 
 { #category : #'instance creation' }

--- a/src/Gnocco-GeneticMutation/GncPopulation.class.st
+++ b/src/Gnocco-GeneticMutation/GncPopulation.class.st
@@ -9,7 +9,7 @@ Class {
 		'crossoverRate',
 		'scores'
 	],
-	#category : #'Gnocco-Genetic Optimization'
+	#category : #'Gnocco-GeneticMutation'
 }
 
 { #category : #configuration }

--- a/src/Gnocco-GeneticMutation/GncPopulationVisualization.class.st
+++ b/src/Gnocco-GeneticMutation/GncPopulationVisualization.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'population'
 	],
-	#category : #'Gnocco-Genetic Optimization'
+	#category : #'Gnocco-GeneticMutation'
 }
 
 { #category : #'accessing - defaults' }

--- a/src/Gnocco-GeneticMutation/GncProfiler.class.st
+++ b/src/Gnocco-GeneticMutation/GncProfiler.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GncProfiler,
 	#superclass : #Object,
-	#category : #Gnocco
+	#category : #'Gnocco-GeneticMutation'
 }
 
 { #category : #'primitives - access' }

--- a/src/Gnocco-GeneticMutation/GncStringIndividual.class.st
+++ b/src/Gnocco-GeneticMutation/GncStringIndividual.class.st
@@ -5,7 +5,7 @@ Class {
 		'parameters',
 		'target'
 	],
-	#category : #'Gnocco-Tests-Genetic Optimization'
+	#category : #'Gnocco-GeneticMutation'
 }
 
 { #category : #'instance creation' }

--- a/src/Gnocco-GeneticMutation/GncStringPopulation.class.st
+++ b/src/Gnocco-GeneticMutation/GncStringPopulation.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'target'
 	],
-	#category : #'Gnocco-Tests-Genetic Optimization'
+	#category : #'Gnocco-GeneticMutation'
 }
 
 { #category : #'instance creation' }

--- a/src/Gnocco-GeneticMutation/package.st
+++ b/src/Gnocco-GeneticMutation/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Gnocco-GeneticMutation' }

--- a/src/Gnocco-Tests/GncCodeGrammar.class.st
+++ b/src/Gnocco-Tests/GncCodeGrammar.class.st
@@ -10,11 +10,6 @@ Class {
 { #category : #initialization }
 GncCodeGrammar >> defineGrammar [
 
-	ntStart --> [ 'oui' ]
-]
-
-{ #category : #accessing }
-GncCodeGrammar >> start [
-
+	ntStart --> [ 'oui' ].
 	^ ntStart
 ]

--- a/src/Gnocco-Tests/GncConcatGrammar.class.st
+++ b/src/Gnocco-Tests/GncConcatGrammar.class.st
@@ -14,11 +14,7 @@ GncConcatGrammar >> defineGrammar [
 
 	ntStart --> ntLiteral1 , ntLiteral2.
 	ntLiteral1 --> 'oui'.
-	ntLiteral2 --> 'non'
-]
-
-{ #category : #accessing }
-GncConcatGrammar >> start [
-
+	ntLiteral2 --> 'non'.
+	
 	^ ntStart
 ]

--- a/src/Gnocco-Tests/GncDisjunctionGrammar.class.st
+++ b/src/Gnocco-Tests/GncDisjunctionGrammar.class.st
@@ -14,11 +14,7 @@ GncDisjunctionGrammar >> defineGrammar [
 
 	ntStart --> ntLiteral1 | ntLiteral2.
 	ntLiteral1 --> 'oui'.
-	ntLiteral2 --> 'non'
-]
-
-{ #category : #accessing }
-GncDisjunctionGrammar >> start [
-
+	ntLiteral2 --> 'non'.
+	
 	^ ntStart
 ]

--- a/src/Gnocco-Tests/GncLiteralGrammar.class.st
+++ b/src/Gnocco-Tests/GncLiteralGrammar.class.st
@@ -10,11 +10,7 @@ Class {
 { #category : #initialization }
 GncLiteralGrammar >> defineGrammar [
 
-	ntLiteral --> 'oui'
-]
-
-{ #category : #accessing }
-GncLiteralGrammar >> start [
-
+	ntLiteral --> 'oui'.
+	
 	^ ntLiteral
 ]

--- a/src/Gnocco-Tests/GncNonProductiveGrammar.class.st
+++ b/src/Gnocco-Tests/GncNonProductiveGrammar.class.st
@@ -12,11 +12,7 @@ Class {
 GncNonProductiveGrammar >> defineGrammar [
 
 	ntStart --> ntSomething.
-	ntSomething --> ntStart
-]
-
-{ #category : #accessing }
-GncNonProductiveGrammar >> start [
-
-	^ ntStart 
+	ntSomething --> ntStart.
+	
+	^ ntStart
 ]

--- a/src/Gnocco-Tests/GncRangeGrammar.class.st
+++ b/src/Gnocco-Tests/GncRangeGrammar.class.st
@@ -10,11 +10,7 @@ Class {
 { #category : #initialization }
 GncRangeGrammar >> defineGrammar [
 
-	ntStart --> ($3 - $5)
-]
-
-{ #category : #accessing }
-GncRangeGrammar >> start [
-
+	ntStart --> ($3 - $5).
+	
 	^ ntStart
 ]

--- a/src/Gnocco-Tests/GncRantomGeneratorTest.class.st
+++ b/src/Gnocco-Tests/GncRantomGeneratorTest.class.st
@@ -1,0 +1,191 @@
+"
+SUnit tests for random generator
+"
+Class {
+	#name : #GncRantomGeneratorTest,
+	#superclass : #ClassTestCase,
+	#instVars : [
+		'gen'
+	],
+	#category : #'Gnocco-Tests'
+}
+
+{ #category : #coverage }
+GncRantomGeneratorTest >> classToBeTested [
+
+	^ Random
+]
+
+{ #category : #helpers }
+GncRantomGeneratorTest >> generateNewSequenceOfSize: aNumber withGenerator: aRandom [
+
+	| results |
+	results := OrderedCollection new.
+
+	1 to: aNumber do: [ :_ |
+	results add: (aRandom nextIntegerBetween: 0 and: 16r7FFFFFFF) ].
+
+	^ results asArray
+]
+
+{ #category : #running }
+GncRantomGeneratorTest >> setUp [
+
+	super setUp.
+	gen := GncPCGRandomGenerator seed: 112629
+]
+
+{ #category : #tests }
+GncRantomGeneratorTest >> testDistribution [
+	| results occurrences generator |
+	1 to: 100 do: [ :i |
+		results := Bag new.
+		generator := Random new seed: 1234567+i.
+		2000 timesRepeat: [ results add: (100 atRandom: generator) ].
+		occurrences := Array new: 100 streamContents: [ :out |
+			results doWithOccurrences: [ :element :occurrence |
+				self assert: (element between: 1 and: 100).
+				out nextPut: occurrence.
+				self assert: (occurrence between: 5 and: 40) ] ].
+		self assert: occurrences average equals: 20.
+		self assert: occurrences stdev < 10]
+]
+
+{ #category : #tests }
+GncRantomGeneratorTest >> testNext [
+
+	10000 timesRepeat: [
+		| next |
+		next := gen next.
+		self assert: (next >= 0).
+		self assert: (next < 1).
+	]
+]
+
+{ #category : #tests }
+GncRantomGeneratorTest >> testNextBetweenAnd [
+
+	10000 timesRepeat: [
+		| next |
+		next := gen nextBetween: -10 and: 5.
+		self assert: (next >= -10).
+		self assert: (next < 5) ]
+]
+
+{ #category : #tests }
+GncRantomGeneratorTest >> testNextInteger [
+	| int |
+	int := gen nextInteger: 256.
+	self assert: int isInteger.
+	self assert: (int between: 1 and: 256)
+]
+
+{ #category : #tests }
+GncRantomGeneratorTest >> testNextIntegerBetweenAnd [
+
+	10000 timesRepeat: [
+		| next |
+		next := gen nextIntegerBetween: -3 and: 5.
+		self assert: next isInteger.
+		self assert: (next between: -3 and: 5) ]
+]
+
+{ #category : #tests }
+GncRantomGeneratorTest >> testNextInto [
+	| array |
+	array := Array new: 8.
+	array := gen next: 8 into: array.
+	self assert: (array allSatisfy: [ :each | each isFloat and: [ each >= 0 and: [ each < 1 ] ] ])
+]
+
+{ #category : #tests }
+GncRantomGeneratorTest >> testPrimitiveRandomGeneration1 [
+
+	self
+		assert:
+		(self generateNewSequenceOfSize: 100 withGenerator: (gen seed: 42))
+		equals:
+			#( 1123384278 1795671209 1924641435 1143034755 1974427309
+			   1757328946 1271345452 1441777623 2062288904 2131966645
+			   898244057 1731076225 106581468 2027215766 1693907025 251273835
+			   872213210 736288324 449296931 1097054660 1174969416 1493913367
+			   727525072 1895983019 2045651843 601924129 790240170 274078875
+			   85460756 661429448 1551229168 1346782475 331806902 2001698278
+			   1653883637 969082088 58484890 877451631 106813142 879896758
+			   1465586082 23970619 222390255 1872327836 132911854 169678554
+			   685616442 1905681248 1101299353 543443413 10498198 1567420440
+			   8429346 246076037 463063522 1131711124 352105423 1100034716
+			   1647334895 972870151 1415116872 419609241 810313841 1259894043
+			   1073135744 969363312 1568528795 664453680 1680803242 460188684
+			   1401049631 1589666895 324952468 2133811574 2125455444 1469931429
+			   387789563 881643062 1751561152 16000064 56618491 1697760127
+			   1756201022 566280575 1702381265 413278598 514120285 2138146072
+			   1826857778 878121720 1338240606 1068671382 403284681 815313315
+			   391109809 395500445 774308967 509549754 1714383213 1069569682 )
+]
+
+{ #category : #tests }
+GncRantomGeneratorTest >> testPrimitiveRandomGeneration2 [
+
+	self
+		assert: (self
+				 generateNewSequenceOfSize: 100
+				 withGenerator: (gen seed: 4112000))
+		equals:
+			#( 911034467 623064739 2069461119 1776170644 2133203577 1730457956
+			   324747982 363675164 1904345172 1621255112 1297556496 23505356
+			   1355834468 160610595 1617487803 1039549212 1846883319 2010354200
+			   476369801 171757954 989848022 1603079100 1314026991 1454207784
+			   2078473025 227444708 504950213 1345591439 600653439 449189537
+			   324817986 914192558 1239256601 395373279 501565559 256583195
+			   715973605 1269777629 314601761 1690741703 155672304 2037828346
+			   1973102905 1150196189 546648478 1888933509 521133230 1757563876
+			   1339955536 431524952 704934916 1711974879 70559250 1982829667
+			   1110020946 1707037755 1973351774 1942247750 1217323071
+			   1125713023 1148575093 364025800 2112712187 1191251157 1293701689
+			   1325582175 848888591 1835433750 198980106 1331838368 602369642
+			   1749496722 1726468786 1537953647 395924263 190370818 949685575
+			   1337449940 918067889 2043992072 374792107 865520841 798576892
+			   554778780 755314185 616251642 1095303820 1762283268 207097256
+			   1698265582 657252139 1166599601 1256604542 1336871508 98506035
+			   1267254030 2056734050 1359495350 1088203006 1024528242 )
+]
+
+{ #category : #tests }
+GncRantomGeneratorTest >> testPrimitiveRandomGeneration3 [
+
+	self
+		assert:
+		(self
+			 generateNewSequenceOfSize: 100
+			 withGenerator: (gen seed: 123456))
+		equals:
+			#( 566038743 1171143710 196292920 1669880209 1144641032 1992765256
+			   659093549 14218717 2061950801 1678079829 1578110325 1879404830
+			   1933870707 434085891 341950436 625432323 1134678563 859685437
+			   1236225730 315560151 852048096 1922244605 925650437 504664098
+			   1260282598 465193379 245828783 279261993 1902667837 5944093
+			   2136271957 1094758864 329209476 105592850 1897929857 1913195112
+			   821050896 643503696 776471402 1415619124 700430832 355145952
+			   1353942448 1074383166 2140513849 159165778 932788109 673910915
+			   1417469399 258047532 939982909 2086845843 1112252639 1003572104
+			   1719096493 2029507176 685431625 1070730662 833670055 2041486110
+			   968545889 1011430722 1287709220 885237954 1257267839 2003737035
+			   935102566 1481687452 1302662897 1254412380 1759700629 1564192767
+			   661511340 227189186 302694750 1035479791 876735686 1001817412
+			   1647194895 440089346 331642580 1825295173 617063505 10834473
+			   863891414 1393364432 1164413488 1487711579 717709665 981313536
+			   1334721008 1303947308 627686644 2053289872 878240920 891827854
+			   498333902 399158151 832415416 1705443437 )
+]
+
+{ #category : #tests }
+GncRantomGeneratorTest >> testUnixRandomGeneratorSeed [
+	"the test is very slow on the CI (>2 minutes)"
+	self skipOnPharoCITestingEnvironment.
+	gen useUnixRandomGeneratorSeed.
+	100 timesRepeat: [ | next |
+			next := gen next.
+			self assert: next >= 0.
+			self assert: next < 1 ]
+]

--- a/src/Gnocco-Tests/GncUndefinedNonTerminalGrammar.class.st
+++ b/src/Gnocco-Tests/GncUndefinedNonTerminalGrammar.class.st
@@ -11,11 +11,7 @@ Class {
 { #category : #initialization }
 GncUndefinedNonTerminalGrammar >> defineGrammar [
 
-	ntStart --> 'a'
-]
-
-{ #category : #accessing }
-GncUndefinedNonTerminalGrammar >> start [
-
+	ntStart --> 'a'.
+	
 	^ ntStart
 ]

--- a/src/Gnocco-Tests/GrammarTestCase.class.st
+++ b/src/Gnocco-Tests/GrammarTestCase.class.st
@@ -10,8 +10,7 @@ GrammarTestCase >> testCanGenerateCost [
 	{
 		GncPhoneGrammar.
 		GncExpressionGrammar.
-		GncWeightedExpressionGrammar.
-		GncStonGrammar } do: [ :grammarClass |
+		GncWeightedExpressionGrammar } do: [ :grammarClass |
 		| grammar generator minimumTreeHeight ast |
 		generator := GncGrammarGenerator new
 			             maxHeightCost: 0;
@@ -57,7 +56,7 @@ GrammarTestCase >> testDisjunctionOui [
 	| grammar generator |
 	grammar := GncDisjunctionGrammar new.
 	generator := GncGrammarGenerator new
-		             seed: 1;
+		             seed: 3;
 		             yourself.
 	self assert: (grammar generate: generator) equals: 'oui'
 ]
@@ -101,7 +100,7 @@ GrammarTestCase >> testRange1 [
 
 	| grammar generator |
 	grammar := GncRangeGrammar new.
-	generator := GncGrammarGenerator new seed: 42; yourself.
+	generator := GncGrammarGenerator new seed: 3; yourself.
 	self assert: (grammar generate: generator) equals: '4'
 ]
 
@@ -110,7 +109,7 @@ GrammarTestCase >> testRange2 [
 
 	| grammar generator |
 	grammar := GncRangeGrammar new.
-	generator := GncGrammarGenerator new seed: 43; yourself.
+	generator := GncGrammarGenerator new seed: 2; yourself.
 	self assert: (grammar generate: generator) equals: '3'
 ]
 
@@ -124,21 +123,6 @@ GrammarTestCase >> testRange3 [
 ]
 
 { #category : #tests }
-GrammarTestCase >> testStonSyntax [
-
-	| grammar |
-	GncFuzzyClass setupFuzzyClasses: 9.
-	grammar := GncStonGrammar new.
-	1 to: 100 do: [ :j |
-		| result |
-		result := STON reader
-			          on: (grammar generate: (GncGrammarGenerator new maxHeightCost: 20; yourself)) readStream;
-			          next.
-		self assert: (result class name beginsWith: 'GncFuzzyClass') ].
-	GncFuzzyClass removeFuzzyClasses: 9
-]
-
-{ #category : #tests }
 GrammarTestCase >> testWeightsNon [
 
 	| grammar generator |
@@ -146,7 +130,7 @@ GrammarTestCase >> testWeightsNon [
 	generator := GncGrammarGenerator new
 		             seed: 17;
 		             yourself.
-	(grammar parameters at: 2) set: 0.
+	(grammar parameters at: 1) set: 0.
 	self assert: (grammar generate: generator) equals: 'non'.
 ]
 

--- a/src/Gnocco/GncExpressionGrammar.class.st
+++ b/src/Gnocco/GncExpressionGrammar.class.st
@@ -29,10 +29,6 @@ GncExpressionGrammar >> defineGrammar [
 		| '(', ntExpression, ')'
 		| ntNumber, '.', ntNumber
 		| ntNumber.
-]
-
-{ #category : #accessing }
-GncExpressionGrammar >> start [
-
+		
 	^ ntExpression
 ]

--- a/src/Gnocco/GncGrammar.class.st
+++ b/src/Gnocco/GncGrammar.class.st
@@ -7,7 +7,8 @@ Class {
 	#traits : 'TFuzzAst',
 	#classTraits : 'TFuzzAst classTrait',
 	#instVars : [
-		'parameters'
+		'parameters',
+		'start'
 	],
 	#category : #'Gnocco-Grammar'
 }
@@ -63,7 +64,7 @@ GncGrammar >> initialize [
 		nonTerminal := GncNonTerminal withName: name.
 		slot write: nonTerminal to: self ].
 
-	self defineGrammar.
+	start := self defineGrammar.
 	"Now, we must compute the minimum cost of expanding a non terminal, and the minimum cost of"
 	"expanding a non terminal with a certain rule. The cost constraints can be expressed with"
 	"the following, mutually recursive set of equations:"
@@ -130,8 +131,8 @@ GncGrammar >> showInInspect [
 		  yourself
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 GncGrammar >> start [
 
-	self subclassResponsibility
+	^ start
 ]

--- a/src/Gnocco/GncGrammarGenerator.class.st
+++ b/src/Gnocco/GncGrammarGenerator.class.st
@@ -11,8 +11,9 @@ Class {
 { #category : #initialization }
 GncGrammarGenerator >> initialize [
 
-	randomGenerator := PMFishmanMooreRandomGenerator new.
-	maxHeightCost := 0.
+	super initialize.
+	randomGenerator := GncPCGRandomGenerator new.
+	maxHeightCost := 0
 ]
 
 { #category : #'accessing - attributes' }

--- a/src/Gnocco/GncPCGRandomGenerator.class.st
+++ b/src/Gnocco/GncPCGRandomGenerator.class.st
@@ -1,0 +1,163 @@
+Class {
+	#name : #GncPCGRandomGenerator,
+	#superclass : #Object,
+	#instVars : [
+		'state',
+		'seed'
+	],
+	#category : #'Gnocco-Grammar'
+}
+
+{ #category : #'instance creation' }
+GncPCGRandomGenerator class >> seed: anInteger [
+
+	^ self new seed: anInteger
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> initialize [
+
+	super initialize.
+	state := DoubleWordArray new: 1.
+	self useClockBasedSeed
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> maxValue [
+
+	^ 16r7FFFFFFF
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> next [
+	"Answer a random Float in the interval [0 to 1)."
+
+	^ (self privateNextValue / (self maxValue + 1)) asFloat
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> next: anInteger [
+
+	^ self next: anInteger into: (Array new: anInteger)
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> next: anInteger into: anArray [
+
+	1 to: anInteger do: [ :index | anArray at: index put: self next ].
+	^ anArray
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> nextBetween: lowerBound and: higherBound [
+	"Answer a random float number from the range [lowerBound, higherBound)"
+
+	^ lowerBound + (self next * (higherBound - lowerBound))
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> nextInteger: anInteger [
+	"Answer a random integer in the interval [1, anInteger].
+	Handle large numbers too (for cryptography)."
+
+	anInteger strictlyPositive ifFalse: [
+		self error: 'Range must be positive' ].
+
+	^ (self privateNextValue / (self maxValue + 1) * anInteger) truncated
+	  + 1
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> nextIntegerBetween: lowerBound and: higherBound [
+	"Answer a random integer number from the inclusive range [lowerBound, higherBound]"
+
+	^ lowerBound + (self nextInteger: higherBound - lowerBound + 1) - 1
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> primitiveRandomNumber: stateArray [
+	"Answer a random Float in the interval [0 to 1)."
+
+	| count returnValue |
+	returnValue := stateArray at: 1.
+
+	count := returnValue >> 59.
+
+	stateArray
+		at: 1
+		put:
+			(returnValue * 6364136223846793005 + 1442695040888963407 bitAnd:
+				 16rFFFFFFFFFFFFFFFF).
+
+	returnValue := returnValue >> 18 bitXor: returnValue.
+
+	returnValue := returnValue >> 27 bitAnd: 16rFFFFFFFF.
+	^ (returnValue >> count bitOr:
+		   returnValue << (count negated bitAnd: 31)) bitAnd: 16r7FFFFFFF
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> privateNextValue [
+	"Answer a random Float in the interval [0 to 1)."
+
+	^ self primitiveRandomNumber: state
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> seed [
+	"Since [1] says...
+	    'After initialization the ideal solution is to hide seed from the user'
+	...this method is placed in the 'private' protocol. Perhaps it sould even be deleted."
+
+	^ seed
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> seed: aNumber [
+	"Refer #privateNextSeed and [1], seed should be positive and less than m"
+
+	seed := aNumber.
+	self setStateFromSeed
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> setStateFromSeed [
+
+	state at: 1 put: seed + 1442695040888963407.
+	self primitiveRandomNumber: state
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> state [
+
+	^ state
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> useClockBasedSeed [
+	"Set a reasonable Park-Miller starting seed [1] based on the ms clock."
+
+	[
+	seed := (Time millisecondClockValue bitAnd: 16rFFFFFFFFFFFFFFFF)
+		        bitXor: self hash.
+	seed = 0 ] whileTrue: [ "Try again if ever get a seed = 0" ].
+
+	self setStateFromSeed
+]
+
+{ #category : #accessing }
+GncPCGRandomGenerator >> useUnixRandomGeneratorSeed [
+	"Try to seed the receiver using random bytes from a Unix OS' /dev/random.
+	Return true if we succeeded, false otherwise.
+	Note that this might block until the OS thinks it has enough entropy."
+
+	^ [
+	  (File named: '/dev/random') readStreamDo: [ :in |
+		  [
+		  seed := (in next: 4) asInteger.
+		  seed isZero ] whileTrue. "Try again if we ever get a zero value"
+		  self setStateFromSeed.
+		  true ] ]
+		  on: Error
+		  do: [ false ]
+]

--- a/src/Gnocco/GncPCGRandomGenerator.class.st
+++ b/src/Gnocco/GncPCGRandomGenerator.class.st
@@ -1,3 +1,54 @@
+"
+This Random Number Generator is an implementation of a Permuted Congruential Generator (https://www.pcg-random.org/index.html)
+
+If you just want a quick random integer, use:
+		10 atRandom
+Every integer interval can give a random number:
+		(6 to: 12) atRandom
+SequenceableCollections can give randomly selected elements:
+		'pick one of these letters randomly' atRandom
+SequenceableCollections also respond to shuffled, as in:
+		($A to: $Z) shuffled
+
+The correct way to use class Random is to store one in an instance or class variable:
+		myGenerator := Random new.
+Then use it every time you need another number between 0.0 and 1.0 (excluding)
+		myGenerator next
+You can also generate a positive integer
+		myGenerator nextInteger: 10
+
+
+The implementation used here is the minimal implementation:
+
+```c
+// *Really* minimal PCG32 code / (c) 2014 M.E. O'Neill / pcg-random.org
+// Licensed under Apache License 2.0 (NO WARRANTY, etc. see website)
+
+typedef struct { uint64_t state;  uint64_t inc; } pcg32_random_t;
+
+uint32_t pcg32_random_r(pcg32_random_t* rng)
+{
+    uint64_t oldstate = rng->state;
+    // Advance internal state
+    rng->state = oldstate * 6364136223846793005ULL + (rng->inc|1);
+    // Calculate output function (XSH RR), uses old state for max ILP
+    uint32_t xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
+    uint32_t rot = oldstate >> 59u;
+    return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
+}
+```
+
+@TechReport{oneill:pcg2014,
+title = """"PCG: A Family of Simple Fast Space-Efficient Statistically Good Algorithms for Random Number Generation"""",
+author = """"Melissa E. O'Neill"""",
+institution = """"Harvey Mudd College"""",
+address = """"Claremont, CA"""",
+number = """"HMC-CS-2014-0905"""",
+year = """"2014"""",
+month = Sep,
+xurl = """"https://www.cs.hmc.edu/tr/hmc-cs-2014-0905.pdf"""",
+}
+"
 Class {
 	#name : #GncPCGRandomGenerator,
 	#superclass : #Object,

--- a/src/Gnocco/GncParameter.class.st
+++ b/src/Gnocco/GncParameter.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GncParameter,
 	#superclass : #Object,
-	#category : #'Gnocco-Genetic Optimization'
+	#category : #'Gnocco-Weight'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Gnocco/GncPhoneGrammar.class.st
+++ b/src/Gnocco/GncPhoneGrammar.class.st
@@ -20,11 +20,7 @@ GncPhoneGrammar >> defineGrammar [
 	ntPhoneNumber 
 		--> ntStartBlock, ' ', ntBlock, ' ', ntBlock, ' ', ntBlock, ' ', ntBlock.
 	ntStartBlock --> '0' , ($1 - $7).
-	ntBlock --> ntDigit , ntDigit
-]
-
-{ #category : #accessing }
-GncPhoneGrammar >> start [
-
-	^ ntPhoneNumber 
+	ntBlock --> ntDigit , ntDigit.
+	
+	^ ntPhoneNumber
 ]

--- a/src/Gnocco/GncStonGrammar.class.st
+++ b/src/Gnocco/GncStonGrammar.class.st
@@ -55,6 +55,7 @@ GncStonGrammar >> defineGrammar [
 	ntValues --> ntObject | ntObject, ', ', ntValues @ 99.
 	
 	ntId --> '' < [ GncLeaf withToken: availableId atRandom printString ].
+	^ ntObjectInstance
 ]
 
 { #category : #translating }
@@ -62,10 +63,4 @@ GncStonGrammar >> generateAst: generator [
 
 	availableId := 0.
 	^ super generateAst: generator
-]
-
-{ #category : #accessing }
-GncStonGrammar >> start [
-
-	^ ntObjectInstance
 ]

--- a/src/Gnocco/GncWeightedExpressionGrammar.class.st
+++ b/src/Gnocco/GncWeightedExpressionGrammar.class.st
@@ -31,10 +31,6 @@ GncWeightedExpressionGrammar >> defineGrammar [
 		| '(', ntExpression, ')' @ 50
 		| ntNumber, '.', ntNumber @ 50
 		| ntNumber @ 50.
-]
-
-{ #category : #accessing }
-GncWeightedExpressionGrammar >> start [
-
+		
 	^ ntExpression
 ]

--- a/src/Gnocco/PMPseudoRandomNumberGenerator.extension.st
+++ b/src/Gnocco/PMPseudoRandomNumberGenerator.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #PMPseudoRandomNumberGenerator }
-
-{ #category : #'*Gnocco' }
-PMPseudoRandomNumberGenerator >> nextInteger: anInteger [
-
-	^ (self next * anInteger) truncated + 1
-]

--- a/src/Gnocco/TFuzzText.trait.st
+++ b/src/Gnocco/TFuzzText.trait.st
@@ -4,7 +4,7 @@ soon :(
 "
 Trait {
 	#name : #TFuzzText,
-	#category : #'Gnocco-Fuzzing Artifact'
+	#category : #'Gnocco-AST'
 }
 
 { #category : #translating }


### PR DESCRIPTION
Split in smaller packages
Slit tests too and make them green

Cleanup grammars to not require the `start` method anymore

Introduce a random generator based on the work in https://github.com/pharo-project/pharo/pull/14230
