### PR TITLE
Added derivation tree size bounds as a constrain during generation

### DIFF
--- a/src/Gnocco-Benchmarks/GncObjectGraph.class.st
+++ b/src/Gnocco-Benchmarks/GncObjectGraph.class.st
@@ -33,8 +33,8 @@ Class {
 { #category : #'instance creation' }
 GncObjectGraph class >> fuzz [
 
-	^ self fuzz: (GncGrammarGenerator new
-			   maxHeightCost: 20;
+	^ self fuzz: (GncGrammarGenerator newUnbounded
+			   maxHeight: 20;
 			   yourself) "Why 20? Why not... :|"
 ]
 

--- a/src/Gnocco-Benchmarks/GncStonGrammar.class.st
+++ b/src/Gnocco-Benchmarks/GncStonGrammar.class.st
@@ -29,9 +29,9 @@ GncStonGrammar >> defineGrammar [
 	ntObjects --> ntObjectInstance
 		| ntObjectInstance, OSPlatform current lineEnding, ntObjects.
 		
-	ntObject --> "ntPrimitive
+	ntObject --> ntPrimitive
 		| ntSymbol
-		|" ntObjectInstance @ 99
+		| ntObjectInstance @ 99
 		| '@', ntId @ [ :weight |
 			availableId isZero ifTrue: [ 0 ] ifFalse: [ weight ] ].
 		

--- a/src/Gnocco-GeneticMutation/GncGrammarIndividual.class.st
+++ b/src/Gnocco-GeneticMutation/GncGrammarIndividual.class.st
@@ -2,8 +2,7 @@ Class {
 	#name : #GncGrammarIndividual,
 	#superclass : #GncIndividual,
 	#instVars : [
-		'grammar',
-		'data'
+		'grammar'
 	],
 	#category : #'Gnocco-GeneticMutation'
 }
@@ -19,7 +18,7 @@ GncGrammarIndividual class >> newFrom: other [
 { #category : #accessing }
 GncGrammarIndividual >> computeScore [
 
-	| "profiler" result |
+	| "profiler" result data |
 	"profiler := PrfMethodProfiler new.
 	profiler addPackage: #'Fuel-Core' asPackage."
 	data := GncObjectGraph with: (STON reader

--- a/src/Gnocco-GeneticMutation/GncGrammarPopulation.class.st
+++ b/src/Gnocco-GeneticMutation/GncGrammarPopulation.class.st
@@ -36,7 +36,7 @@ GncGrammarPopulation class >> newWithGrammar: grammarClass andGenerator: generat
 GncGrammarPopulation class >> newWithGrammar: grammarClass andMaxHeight: maxHeight [
 
 	^ self newWithGrammar: grammarClass andGenerator: (GncGrammarGenerator new
-			   maxHeightCost: maxHeight;
+			   maxHeight: maxHeight;
 			   yourself)
 ]
 

--- a/src/Gnocco-Tests/GrammarTestCase.class.st
+++ b/src/Gnocco-Tests/GrammarTestCase.class.st
@@ -55,7 +55,7 @@ GrammarTestCase >> testDisjunctionOui [
 	| grammar generator |
 	grammar := GncDisjunctionGrammar new.
 	generator := GncGrammarGenerator newMinimal
-		             seed: 1;
+		             seed: 3;
 		             yourself.
 	self assert: (grammar generate: generator) equals: 'oui'
 ]
@@ -99,7 +99,7 @@ GrammarTestCase >> testRange1 [
 
 	| grammar generator |
 	grammar := GncRangeGrammar new.
-	generator := GncGrammarGenerator newMinimal seed: 42; yourself.
+	generator := GncGrammarGenerator newMinimal seed: 3; yourself.
 	self assert: (grammar generate: generator) equals: '4'
 ]
 
@@ -108,7 +108,7 @@ GrammarTestCase >> testRange2 [
 
 	| grammar generator |
 	grammar := GncRangeGrammar new.
-	generator := GncGrammarGenerator newMinimal seed: 43; yourself.
+	generator := GncGrammarGenerator newMinimal seed: 2; yourself.
 	self assert: (grammar generate: generator) equals: '3'
 ]
 
@@ -117,7 +117,7 @@ GrammarTestCase >> testRange3 [
 
 	| grammar generator |
 	grammar := GncRangeGrammar new.
-	generator := GncGrammarGenerator newMinimal seed: 45; yourself.
+	generator := GncGrammarGenerator newMinimal seed: 1; yourself.
 	self assert: (grammar generate: generator) equals: '5'
 ]
 

--- a/src/Gnocco-Tests/GrammarTestCase.class.st
+++ b/src/Gnocco-Tests/GrammarTestCase.class.st
@@ -12,8 +12,7 @@ GrammarTestCase >> testCanGenerateCost [
 		GncExpressionGrammar.
 		GncWeightedExpressionGrammar } do: [ :grammarClass |
 		| grammar generator minimumTreeHeight ast |
-		generator := GncGrammarGenerator new
-			             maxHeightCost: 0;
+		generator := GncGrammarGenerator newMinimal
 			             seed: 17;
 			             yourself.
 		grammar := grammarClass new.
@@ -44,7 +43,7 @@ GrammarTestCase >> testDisjunctionNon [
 
 	| grammar generator |
 	grammar := GncDisjunctionGrammar new.
-	generator := GncGrammarGenerator new
+	generator := GncGrammarGenerator newMinimal
 		             seed: 42;
 		             yourself.
 	self assert: (grammar generate: generator) equals: 'non'
@@ -55,8 +54,8 @@ GrammarTestCase >> testDisjunctionOui [
 
 	| grammar generator |
 	grammar := GncDisjunctionGrammar new.
-	generator := GncGrammarGenerator new
-		             seed: 3;
+	generator := GncGrammarGenerator newMinimal
+		             seed: 1;
 		             yourself.
 	self assert: (grammar generate: generator) equals: 'oui'
 ]
@@ -100,7 +99,7 @@ GrammarTestCase >> testRange1 [
 
 	| grammar generator |
 	grammar := GncRangeGrammar new.
-	generator := GncGrammarGenerator new seed: 3; yourself.
+	generator := GncGrammarGenerator newMinimal seed: 42; yourself.
 	self assert: (grammar generate: generator) equals: '4'
 ]
 
@@ -109,7 +108,7 @@ GrammarTestCase >> testRange2 [
 
 	| grammar generator |
 	grammar := GncRangeGrammar new.
-	generator := GncGrammarGenerator new seed: 2; yourself.
+	generator := GncGrammarGenerator newMinimal seed: 43; yourself.
 	self assert: (grammar generate: generator) equals: '3'
 ]
 
@@ -118,7 +117,7 @@ GrammarTestCase >> testRange3 [
 
 	| grammar generator |
 	grammar := GncRangeGrammar new.
-	generator := GncGrammarGenerator new seed: 45; yourself.
+	generator := GncGrammarGenerator newMinimal seed: 45; yourself.
 	self assert: (grammar generate: generator) equals: '5'
 ]
 
@@ -127,7 +126,7 @@ GrammarTestCase >> testWeightsNon [
 
 	| grammar generator |
 	grammar := GncDisjunctionGrammar new.
-	generator := GncGrammarGenerator new
+	generator := GncGrammarGenerator newMinimal
 		             seed: 17;
 		             yourself.
 	(grammar parameters at: 1) set: 0.
@@ -139,7 +138,7 @@ GrammarTestCase >> testWeightsOui [
 
 	| grammar generator |
 	grammar := GncDisjunctionGrammar new.
-	generator := GncGrammarGenerator new
+	generator := GncGrammarGenerator newMinimal
 		             seed: 17;
 		             yourself.
 	(grammar parameters at: 3) set: 0.

--- a/src/Gnocco/GncGrammar.class.st
+++ b/src/Gnocco/GncGrammar.class.st
@@ -46,13 +46,16 @@ GncGrammar >> eachNonTerminalSlot: body [
 { #category : #translating }
 GncGrammar >> generateAst: generator [
 
-	^ self start generateAst: (generator offsetHeightCost: self minHeight)
+	^ self start generateAst:
+		  (generator
+			   offsetHeightCost: self minHeight
+			   andSizeCost: self minSize)
 ]
 
 { #category : #translating }
 GncGrammar >> generateWithMinCost [
 
-	^ self generate: (GncGrammarGenerator new)
+	^ self generate: (GncGrammarGenerator newMinimal)
 ]
 
 { #category : #initialization }
@@ -103,6 +106,12 @@ GncGrammar >> initialize [
 GncGrammar >> minHeight [
 
 	^ self start minHeight
+]
+
+{ #category : #accessing }
+GncGrammar >> minSize [
+
+	^ self start minSize
 ]
 
 { #category : #initialization }

--- a/src/Gnocco/GncGrammarGenerator.class.st
+++ b/src/Gnocco/GncGrammarGenerator.class.st
@@ -2,8 +2,8 @@ Class {
 	#name : #GncGrammarGenerator,
 	#superclass : #GncVisitor,
 	#instVars : [
-		'maxSize',
 		'randomGenerator',
+		'maxSize',
 		'maxHeight'
 	],
 	#category : #'Gnocco-Visitors'
@@ -32,7 +32,6 @@ GncGrammarGenerator >> initialize [
 
 	super initialize.
 	randomGenerator := GncPCGRandomGenerator new.
-	maxHeightCost := 0
 ]
 
 { #category : #'accessing - attributes' }

--- a/src/Gnocco/GncGrammarGenerator.class.st
+++ b/src/Gnocco/GncGrammarGenerator.class.st
@@ -2,11 +2,30 @@ Class {
 	#name : #GncGrammarGenerator,
 	#superclass : #GncVisitor,
 	#instVars : [
-		'maxHeightCost',
-		'randomGenerator'
+		'maxSize',
+		'randomGenerator',
+		'maxHeight'
 	],
 	#category : #'Gnocco-Visitors'
 }
+
+{ #category : #'instance creation' }
+GncGrammarGenerator class >> newMinimal [
+
+	^ self new
+		  maxHeight: 0;
+		  maxSize: 0;
+		  yourself
+]
+
+{ #category : #'instance creation' }
+GncGrammarGenerator class >> newUnbounded [
+
+	^ self new
+		  maxHeight: Float infinity;
+		  maxSize: Float infinity;
+		  yourself
+]
 
 { #category : #initialization }
 GncGrammarGenerator >> initialize [
@@ -17,16 +36,39 @@ GncGrammarGenerator >> initialize [
 ]
 
 { #category : #'accessing - attributes' }
-GncGrammarGenerator >> maxHeightCost: cost [
+GncGrammarGenerator >> maxHeight: cost [
 
-	maxHeightCost := cost
+	maxHeight := cost
+]
+
+{ #category : #'accessing - attributes' }
+GncGrammarGenerator >> maxSize: cost [
+
+	maxSize := cost
 ]
 
 { #category : #'accessing - attributes' }
 GncGrammarGenerator >> offsetHeightCost: offset [
 
 	^ self clone
-		  maxHeightCost: maxHeightCost + offset;
+		  maxHeight: maxHeight + offset;
+		  yourself
+]
+
+{ #category : #'accessing - attributes' }
+GncGrammarGenerator >> offsetHeightCost: offset andSizeCost: size [
+
+	^ self clone
+		  maxHeight: maxHeight + offset;
+		  maxSize: maxSize + size;
+		  yourself
+]
+
+{ #category : #'accessing - attributes' }
+GncGrammarGenerator >> offsetSizeCost: offset [
+
+	^ self clone
+		  maxSize: maxSize + offset;
 		  yourself
 ]
 
@@ -53,18 +95,18 @@ GncGrammarGenerator >> selectRule: rules [
 	For this reason, we compute the weight only once, and we store the result alongside the rule."
 	rulesWithWeight := rules
 		                   select: [ :rule |
-		                   rule minHeight < maxHeightCost ]
+		                   rule minHeight < maxHeight and: [
+			                   rule minSize < maxSize ] ]
 		                   thenCollect: [ :rule | rule -> rule weight ].
 	self assert: rulesWithWeight isNotEmpty.
-	rulesWithWeight
-		do: [ :ruleAndWeight |
+	
+	rulesWithWeight do: [ :ruleAndWeight |
 		totalWeight := totalWeight + ruleAndWeight value ].
 	selected := totalWeight atRandom: self random.
-	rulesWithWeight
-		do: [ :ruleAndWeight |
-			ruleAndWeight value >= selected
-				ifTrue: [ ^ ruleAndWeight key ]
-				ifFalse: [ selected := selected - ruleAndWeight value ] ].
+	rulesWithWeight do: [ :ruleAndWeight |
+		ruleAndWeight value >= selected
+			ifTrue: [ ^ ruleAndWeight key ]
+			ifFalse: [ selected := selected - ruleAndWeight value ] ].
 	Error signal: 'what?'
 ]
 
@@ -84,9 +126,25 @@ GncGrammarGenerator >> visitNonTerminal: nonTerminal [
 { #category : #visiting }
 GncGrammarGenerator >> visitRule: rule [
 
-	| result |
+	| result availableSize |
 	rule preHook ifNotNil: [ :hook | ^ hook value ].
-	result := rule fragments collect: [ :fragment | fragment visit: self ].
+	"The total size of the children is bounded by the total size of this subtree
+	minus the size of the root, which is 1."
+	availableSize := maxSize - 1.
+
+	"Remove from `availableSize` the incompressible size, so that when generating
+	a subtree, we don't eat away the space required for other subtrees."
+	rule fragments do: [ :fragment |
+		availableSize := availableSize - fragment minSize ].
+
+	result := rule fragments collect: [ :fragment |
+		          | node |
+		          "in addition to the remaining space for generation, there is
+		the incompressible size, which is only available for *this* subtree."
+		          availableSize := availableSize + fragment minSize.
+		          node := fragment visit: (self withSize: availableSize).
+		          availableSize := availableSize - node treeSize.
+		          node ].
 	rule postHook ifNotNil: [ :hook | hook cull: result ].
 	^ GncInnerNode with: result
 ]
@@ -94,13 +152,22 @@ GncGrammarGenerator >> visitRule: rule [
 { #category : #visiting }
 GncGrammarGenerator >> visitTerminal: terminal [
 
+	maxSize update: [ :size | size - 1 ].
 	^ terminal generateAst: self
+]
+
+{ #category : #private }
+GncGrammarGenerator >> withSize: size [
+
+	^ self clone
+		  maxSize: size;
+		  yourself
 ]
 
 { #category : #private }
 GncGrammarGenerator >> withSubLevel [
 
 	^ self clone
-		  maxHeightCost: maxHeightCost - 1;
+		  maxHeight: maxHeight - 1;
 		  yourself
 ]

--- a/src/Gnocco/GncLeaf.class.st
+++ b/src/Gnocco/GncLeaf.class.st
@@ -31,6 +31,12 @@ Class {
 }
 
 { #category : #'instance creation' }
+GncLeaf class >> treeSize [
+
+	^ 1
+]
+
+{ #category : #'instance creation' }
 GncLeaf class >> withToken: token [
 
 	^ self new token: token
@@ -63,5 +69,5 @@ GncLeaf >> treeHeight [
 { #category : #translating }
 GncLeaf >> treeSize [
 
-	^ 1
+	^ self class treeSize
 ]

--- a/src/Gnocco/GncMinSizeComputer.class.st
+++ b/src/Gnocco/GncMinSizeComputer.class.st
@@ -25,16 +25,16 @@ GncMinSizeComputer >> visitNonTerminalOnce: nonTerminal [
 { #category : #visiting }
 GncMinSizeComputer >> visitRule: rule [
 
-	| minHeight |
-	minHeight := 0.
+	| minSize |
+	minSize := 0.
 	rule fragments do: [ :fragment |
-		minHeight := minHeight + (fragment visit: self) ].
-	rule minHeight: (rule minHeight min: minHeight).
-	^ rule minHeight
+		minSize := minSize + (fragment visit: self) ].
+	rule minSize: (rule minSize min: minSize).
+	^ rule minSize
 ]
 
 { #category : #visiting }
 GncMinSizeComputer >> visitTerminal: terminal [
 
-	^ terminal minHeight
+	^ terminal minSize
 ]

--- a/src/Gnocco/GncRule.class.st
+++ b/src/Gnocco/GncRule.class.st
@@ -94,6 +94,12 @@ GncRule >> minSize [
 ]
 
 { #category : #translating }
+GncRule >> minSize: newSize [
+
+	minSize := newSize
+]
+
+{ #category : #translating }
 GncRule >> post: postCallback [
 
 	postHook := postCallback
@@ -126,6 +132,8 @@ GncRule >> printOn: stream [
 	stream
 		<< '(';
 		print: self minHeight;
+		<< '/';
+		print: self minSize;
 		<< ') [';
 		print: weight;
 		<< ']'

--- a/src/Gnocco/GncTerminal.class.st
+++ b/src/Gnocco/GncTerminal.class.st
@@ -13,7 +13,7 @@ GncTerminal >> minHeight [
 { #category : #accessing }
 GncTerminal >> minSize [
 
-	^ 1
+	^ GncLeaf treeSize
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
The generator `GncGrammarGenerator` can now be constrained by the maximum size of the generated derivation tree, in addition to its height. All constrains can also be relaxed by setting them to `Float infinity`.

Additionally, this introduces a "bug": there is no guarantee that the smallest (in size) derivation tree is also the smallest (in height) derivation tree, so generating a "minimal" derivation tree might not work.